### PR TITLE
fix: remove deprecated CommunityToolkit.WinUI.Notifications

### DIFF
--- a/winui3/Directory.Packages.props
+++ b/winui3/Directory.Packages.props
@@ -7,7 +7,6 @@
     <!-- WinUI3 Application -->
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.260209005" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7705" />
-    <PackageVersion Include="CommunityToolkit.WinUI.Notifications" Version="7.1.2" />
     <PackageVersion Include="System.Drawing.Common" Version="10.0.3" />
 
     <!-- Code Analysis -->

--- a/winui3/WSLKernelWatcher.WinUI3/WSLKernelWatcher.WinUI3.csproj
+++ b/winui3/WSLKernelWatcher.WinUI3/WSLKernelWatcher.WinUI3.csproj
@@ -30,7 +30,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" />
-    <PackageReference Include="CommunityToolkit.WinUI.Notifications" />
     <PackageReference Include="System.Drawing.Common" />
 
     <!-- Code Analysis -->


### PR DESCRIPTION
## 概要

Renovate Dependency Dashboard (Issue #4) の Warning を解消する。

廃止予定パッケージ `CommunityToolkit.WinUI.Notifications` を削除する。

## 変更内容

- `winui3/Directory.Packages.props` から `CommunityToolkit.WinUI.Notifications 7.1.2` を削除
- `winui3/WSLKernelWatcher.WinUI3/WSLKernelWatcher.WinUI3.csproj` から PackageReference を削除

## 背景

コードはすでに `Microsoft.Windows.AppNotifications`（Windows App SDK 組み込みの通知 API）へ完全移行済みであり、
`CommunityToolkit.WinUI.Notifications` はまったく使用されていない残骸参照だった。

Renovate は NuGet 上の deprecated 表記を検出したが、代替パッケージへの自動移行 PR を生成できない (unavailable) 状態のため、手動で対処する。

## テスト

- `dotnet build` 0 warning / 0 error
- `dotnet test` 28 件合格（Line 89.61% / Branch 83.33% / Method 89.47%）

Closes #4